### PR TITLE
Update WayOfTheJester.cs

### DIFF
--- a/FFC/MonoBehaviours/WayOfTheJester.cs
+++ b/FFC/MonoBehaviours/WayOfTheJester.cs
@@ -21,15 +21,17 @@ namespace FFC.MonoBehaviours {
         }
 
         private void Update() {
-            if (_bounces == _previousBounces || _bounces > 25) return;
+            if (_bounces == _previousBounces || ((_bounces > 25) && (_previousBounces >= 25))) return;
 
             UnityEngine.Debug.Log($"[FFC] _bounces: {_bounces}");
+            
+            int _difference = Mathf.Min(_bounces, 25) - _previousBounces;
 
             _previousBounces = _bounces;
 
-            _stats.movementSpeed += _bounces * MovementSpeed;
-            _gun.damage += _bounces * Damage;
-            _gun.projectileSpeed += _bounces * ProjectileSpeed;
+            _stats.movementSpeed *= Mathf.Pow(1f + MovementSpeed, _difference);
+            _gun.damage *= Mathf.Pow(1f + Damage, _difference);
+            _gun.projectileSpeed *= Mathf.Pow(1f + ProjectileSpeed, _difference);
         }
     }
 }


### PR DESCRIPTION
- Causes it to only return if previous bounces had reached the 25 bounce cap.
- Causes the stats to actually increase yours based on a multiplicative % per bounce. For an additive % per bounce, you'll need to divide first before setting previous bounces and then multiply as below.
```CSHARP
_stats.movementSpeed /= 1f + (_previousBounces * MovementSpeed);
_gun.damage /= 1f + (_previousBounces * Damage);
_gun.projectileSpeed /= 1f + (_previousBounces * ProjectileSpeed);

_previousBounces = _bounces;

_stats.movementSpeed /= 1f + (_bounces * MovementSpeed);
_gun.damage /= 1f + (_bounces * Damage);
_gun.projectileSpeed /= 1f + (_bounces * ProjectileSpeed);
```